### PR TITLE
Mod Disabler API

### DIFF
--- a/api/src/main/java/net/digitalingot/feather/serverapi/api/FeatherAPI.java
+++ b/api/src/main/java/net/digitalingot/feather/serverapi/api/FeatherAPI.java
@@ -1,6 +1,7 @@
 package net.digitalingot.feather.serverapi.api;
 
 import net.digitalingot.feather.serverapi.api.event.EventService;
+import net.digitalingot.feather.serverapi.api.mod.FeatherModService;
 import net.digitalingot.feather.serverapi.api.player.PlayerService;
 import net.digitalingot.feather.serverapi.api.ui.UIService;
 import net.digitalingot.feather.serverapi.api.waypoint.WaypointService;
@@ -58,5 +59,13 @@ public final class FeatherAPI {
   @NotNull
   public static WaypointService getWaypointService() {
     return featherService.getWaypointService();
+  }
+
+  /**
+   * @see FeatherService#getFeatherModService() ()
+   */
+  @NotNull
+  public static FeatherModService getFeatherModService() {
+    return featherService.getFeatherModService();
   }
 }

--- a/api/src/main/java/net/digitalingot/feather/serverapi/api/FeatherService.java
+++ b/api/src/main/java/net/digitalingot/feather/serverapi/api/FeatherService.java
@@ -1,6 +1,7 @@
 package net.digitalingot.feather.serverapi.api;
 
 import net.digitalingot.feather.serverapi.api.event.EventService;
+import net.digitalingot.feather.serverapi.api.mod.FeatherModService;
 import net.digitalingot.feather.serverapi.api.player.PlayerService;
 import net.digitalingot.feather.serverapi.api.ui.UIService;
 import net.digitalingot.feather.serverapi.api.waypoint.WaypointService;
@@ -18,4 +19,7 @@ public interface FeatherService {
 
   @NotNull
   WaypointService getWaypointService();
+
+  @NotNull
+  FeatherModService getFeatherModService();
 }

--- a/api/src/main/java/net/digitalingot/feather/serverapi/api/mod/FeatherModService.java
+++ b/api/src/main/java/net/digitalingot/feather/serverapi/api/mod/FeatherModService.java
@@ -1,0 +1,39 @@
+package net.digitalingot.feather.serverapi.api.mod;
+
+import net.digitalingot.feather.serverapi.api.model.FeatherMod;
+import net.digitalingot.feather.serverapi.api.player.FeatherPlayer;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public interface FeatherModService {
+
+    /**
+     * Disables the selected feather mods for the player
+     *
+     * @param player
+     * The player whose mods will be disabled
+     * @param mods
+     * The list of mods to disable
+     */
+    void disableMods(@NotNull FeatherPlayer player, @NotNull List<FeatherMod> mods);
+
+    /**
+     * Re-enables the selected feather mods for the player
+     *
+     * @param player
+     * The player whose mods will be re-enabled
+     * @param mods
+     * The list of mods to re-enable
+     */
+    void reEnableMods(@NotNull FeatherPlayer player, @NotNull List<FeatherMod> mods);
+
+    /**
+     * Returns the list of disabled feather mods for the player
+     *
+     * @param player
+     * The player whose mods are disabled
+     */
+    List<FeatherMod> getDisabledMods(@NotNull FeatherPlayer player);
+
+}

--- a/bukkit/src/main/java/net/digitalingot/feather/serverapi/bukkit/BukkitFeatherService.java
+++ b/bukkit/src/main/java/net/digitalingot/feather/serverapi/bukkit/BukkitFeatherService.java
@@ -2,10 +2,12 @@ package net.digitalingot.feather.serverapi.bukkit;
 
 import net.digitalingot.feather.serverapi.api.FeatherService;
 import net.digitalingot.feather.serverapi.api.event.EventService;
+import net.digitalingot.feather.serverapi.api.mod.FeatherModService;
 import net.digitalingot.feather.serverapi.api.player.PlayerService;
 import net.digitalingot.feather.serverapi.api.ui.UIService;
 import net.digitalingot.feather.serverapi.api.waypoint.WaypointService;
 import net.digitalingot.feather.serverapi.bukkit.event.BukkitEventService;
+import net.digitalingot.feather.serverapi.bukkit.mod.BukkitFeatherModService;
 import net.digitalingot.feather.serverapi.bukkit.player.BukkitPlayerService;
 import net.digitalingot.feather.serverapi.bukkit.ui.BukkitUIService;
 import org.jetbrains.annotations.NotNull;
@@ -14,14 +16,17 @@ public class BukkitFeatherService implements FeatherService {
   private final BukkitEventService eventService;
   private final BukkitPlayerService playerService;
   private final BukkitUIService uiService;
+  private final BukkitFeatherModService featherModService;
 
   public BukkitFeatherService(
       BukkitEventService eventService,
       BukkitPlayerService playerService,
-      BukkitUIService uiService) {
+      BukkitUIService uiService,
+      BukkitFeatherModService featherModService) {
     this.eventService = eventService;
     this.playerService = playerService;
     this.uiService = uiService;
+    this.featherModService = featherModService;
   }
 
   @Override
@@ -43,4 +48,10 @@ public class BukkitFeatherService implements FeatherService {
   public @NotNull WaypointService getWaypointService() {
     throw new UnsupportedOperationException("Not implemented");
   }
+
+  @Override
+  public @NotNull FeatherModService getFeatherModService() {
+    return this.featherModService;
+  }
+
 }

--- a/bukkit/src/main/java/net/digitalingot/feather/serverapi/bukkit/FeatherBukkitPlugin.java
+++ b/bukkit/src/main/java/net/digitalingot/feather/serverapi/bukkit/FeatherBukkitPlugin.java
@@ -3,6 +3,7 @@ package net.digitalingot.feather.serverapi.bukkit;
 import net.digitalingot.feather.serverapi.api.FeatherAPI;
 import net.digitalingot.feather.serverapi.bukkit.event.BukkitEventService;
 import net.digitalingot.feather.serverapi.bukkit.messaging.BukkitMessagingService;
+import net.digitalingot.feather.serverapi.bukkit.mod.BukkitFeatherModService;
 import net.digitalingot.feather.serverapi.bukkit.player.BukkitPlayerService;
 import net.digitalingot.feather.serverapi.bukkit.ui.BukkitUIService;
 import net.digitalingot.feather.serverapi.bukkit.ui.rpc.RpcService;
@@ -18,13 +19,16 @@ public class FeatherBukkitPlugin extends JavaPlugin {
   public void onEnable() {
     BukkitEventService eventService = new BukkitEventService(this);
     BukkitPlayerService playerService = new BukkitPlayerService(this);
+
     RpcService rpcService = new RpcService(this);
     BukkitMessagingService messagingService =
         new BukkitMessagingService(this, playerService, rpcService);
     BukkitUIService uiService = new BukkitUIService(messagingService, rpcService);
 
+    BukkitFeatherModService featherModService = new BukkitFeatherModService(messagingService);
+
     BukkitFeatherService bukkitFeatherService =
-        new BukkitFeatherService(eventService, playerService, uiService);
+        new BukkitFeatherService(eventService, playerService, uiService, featherModService);
     FeatherAPI.register(bukkitFeatherService);
 
     super.onEnable();

--- a/bukkit/src/main/java/net/digitalingot/feather/serverapi/bukkit/mod/BukkitFeatherModService.java
+++ b/bukkit/src/main/java/net/digitalingot/feather/serverapi/bukkit/mod/BukkitFeatherModService.java
@@ -1,0 +1,48 @@
+package net.digitalingot.feather.serverapi.bukkit.mod;
+
+import net.digitalingot.feather.serverapi.api.mod.FeatherModService;
+import net.digitalingot.feather.serverapi.api.model.FeatherMod;
+import net.digitalingot.feather.serverapi.api.player.FeatherPlayer;
+import net.digitalingot.feather.serverapi.bukkit.messaging.BukkitMessagingService;
+import net.digitalingot.feather.serverapi.bukkit.player.BukkitFeatherPlayer;
+import net.digitalingot.feather.serverapi.messaging.messages.client.S2CPluginModDisable;
+import net.digitalingot.feather.serverapi.messaging.messages.client.S2CPluginModReEnable;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class BukkitFeatherModService implements FeatherModService {
+
+  Map<FeatherPlayer, Set<FeatherMod>> playerDisabledMods = new HashMap<>();
+
+  BukkitMessagingService messagingService;
+
+  public BukkitFeatherModService(BukkitMessagingService messagingService) {
+    this.messagingService = messagingService;
+  }
+
+  @Override
+  public void disableMods(@NotNull FeatherPlayer player, @NotNull List<FeatherMod> mods) {
+    Set<FeatherMod> disabledMods = playerDisabledMods.computeIfAbsent(player, k -> new HashSet<>());
+    disabledMods.addAll(mods);
+
+    messagingService.sendMessage((BukkitFeatherPlayer) player, new S2CPluginModDisable(mods.stream().map(
+            (featherMod -> new net.digitalingot.feather.serverapi.messaging.domain.FeatherMod(featherMod.getName()))).collect(Collectors.toList())));
+  }
+
+  @Override
+  public void reEnableMods(@NotNull FeatherPlayer player, @NotNull List<FeatherMod> mods) {
+    Set<FeatherMod> disabledMods = playerDisabledMods.getOrDefault(player, new HashSet<>());
+    mods.forEach(disabledMods::remove);
+
+    if (disabledMods.isEmpty()) playerDisabledMods.remove(player);
+    messagingService.sendMessage((BukkitFeatherPlayer) player, new S2CPluginModReEnable(mods.stream().map(
+            (featherMod -> new net.digitalingot.feather.serverapi.messaging.domain.FeatherMod(featherMod.getName()))).collect(Collectors.toList())));
+  }
+
+  @Override
+  public List<FeatherMod> getDisabledMods(@NotNull FeatherPlayer player) {
+    return playerDisabledMods.getOrDefault(player, new HashSet<>()).stream().collect(Collectors.toList());
+  }
+}

--- a/examples/bukkit/src/main/java/net/digitalingot/feather/serverapi/examples/bukkit/ExamplePlugin.java
+++ b/examples/bukkit/src/main/java/net/digitalingot/feather/serverapi/examples/bukkit/ExamplePlugin.java
@@ -25,10 +25,7 @@ import org.jetbrains.annotations.NotNull;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 
 public class ExamplePlugin extends JavaPlugin implements Listener {
@@ -139,6 +136,9 @@ public class ExamplePlugin extends JavaPlugin implements Listener {
                           + event.getFeatherMods().stream()
                               .map(FeatherMod::getName)
                               .collect(Collectors.joining(", ")));
+
+              //Disable perspective mod on player join
+              FeatherAPI.getFeatherModService().disableMods(event.getPlayer(), Arrays.asList(new FeatherMod("perspective")));
 
               FeatherAPI.getUIService().createPageForPlayer(event.getPlayer(), this.page);
             });

--- a/messaging/src/main/java/net/digitalingot/feather/serverapi/messaging/ClientMessageHandler.java
+++ b/messaging/src/main/java/net/digitalingot/feather/serverapi/messaging/ClientMessageHandler.java
@@ -1,10 +1,6 @@
 package net.digitalingot.feather.serverapi.messaging;
 
-import net.digitalingot.feather.serverapi.messaging.messages.client.S2CCreateFUI;
-import net.digitalingot.feather.serverapi.messaging.messages.client.S2CDestroyFUI;
-import net.digitalingot.feather.serverapi.messaging.messages.client.S2CFUIMessage;
-import net.digitalingot.feather.serverapi.messaging.messages.client.S2CFUIResponse;
-import net.digitalingot.feather.serverapi.messaging.messages.client.S2CSetFUIState;
+import net.digitalingot.feather.serverapi.messaging.messages.client.*;
 
 public interface ClientMessageHandler extends MessageHandler {
   void handle(S2CCreateFUI createFUI);
@@ -16,4 +12,8 @@ public interface ClientMessageHandler extends MessageHandler {
   void handle(S2CFUIMessage message);
 
   void handle(S2CFUIResponse response);
+
+  void handle(S2CPluginModDisable modDisable);
+
+  void handle(S2CPluginModReEnable modReEnable);
 }

--- a/messaging/src/main/java/net/digitalingot/feather/serverapi/messaging/messages/client/S2CPluginModDisable.java
+++ b/messaging/src/main/java/net/digitalingot/feather/serverapi/messaging/messages/client/S2CPluginModDisable.java
@@ -1,0 +1,35 @@
+package net.digitalingot.feather.serverapi.messaging.messages.client;
+
+import net.digitalingot.feather.serverapi.messaging.ClientMessageHandler;
+import net.digitalingot.feather.serverapi.messaging.Message;
+import net.digitalingot.feather.serverapi.messaging.MessageReader;
+import net.digitalingot.feather.serverapi.messaging.MessageWriter;
+import net.digitalingot.feather.serverapi.messaging.domain.FeatherMod;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public class S2CPluginModDisable implements Message<ClientMessageHandler> {
+    private final Collection<FeatherMod> featherMods;
+
+    public S2CPluginModDisable(@NotNull Collection<FeatherMod> featherMods) {
+        this.featherMods = featherMods;
+    }
+
+    public S2CPluginModDisable(MessageReader reader) {
+        this.featherMods = reader.readList(FeatherMod.DECODER);
+    }
+
+    public void write(MessageWriter writer) {
+        writer.writeCollection(this.featherMods, FeatherMod.ENCODER);
+    }
+
+    public void handle(ClientMessageHandler handler) {
+        handler.handle(this);
+    }
+
+    public Collection<FeatherMod> getFeatherMods() {
+        return this.featherMods;
+    }
+
+}

--- a/messaging/src/main/java/net/digitalingot/feather/serverapi/messaging/messages/client/S2CPluginModReEnable.java
+++ b/messaging/src/main/java/net/digitalingot/feather/serverapi/messaging/messages/client/S2CPluginModReEnable.java
@@ -1,0 +1,35 @@
+package net.digitalingot.feather.serverapi.messaging.messages.client;
+
+import net.digitalingot.feather.serverapi.messaging.ClientMessageHandler;
+import net.digitalingot.feather.serverapi.messaging.Message;
+import net.digitalingot.feather.serverapi.messaging.MessageReader;
+import net.digitalingot.feather.serverapi.messaging.MessageWriter;
+import net.digitalingot.feather.serverapi.messaging.domain.FeatherMod;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+
+public class S2CPluginModReEnable implements Message<ClientMessageHandler> {
+    private final Collection<FeatherMod> featherMods;
+
+    public S2CPluginModReEnable(@NotNull Collection<FeatherMod> featherMods) {
+        this.featherMods = featherMods;
+    }
+
+    public S2CPluginModReEnable(MessageReader reader) {
+        this.featherMods = reader.readList(FeatherMod.DECODER);
+    }
+
+    public void write(MessageWriter writer) {
+        writer.writeCollection(this.featherMods, FeatherMod.ENCODER);
+    }
+
+    public void handle(ClientMessageHandler handler) {
+        handler.handle(this);
+    }
+
+    public Collection<FeatherMod> getFeatherMods() {
+        return this.featherMods;
+    }
+
+}


### PR DESCRIPTION
* Plugins can disable & re-enable feather mods
* Disabled mods are tracked universally between plugins of the same type (should be refactored to have a universal list of disabled plugins later or when support for plugin types other than Bukkit is added)